### PR TITLE
feat: update Japanese translation 

### DIFF
--- a/public/locales/en/setting.json
+++ b/public/locales/en/setting.json
@@ -56,8 +56,8 @@
       "title": "Language",
       "desc": "Setting the language",
       "en": "English",
-      "zh": "Chinese",
-      "jp": "Japanese"
+      "zh": "中文",
+      "jp": "日本語"
     }
   },
   "license": {

--- a/public/locales/jp/auth.json
+++ b/public/locales/jp/auth.json
@@ -18,6 +18,11 @@
     "oidc": "OIDCで登録する",
     "have_account": "アカウントをお持ちでる？"
   },
+  "logout": {
+    "title": "ログアウト",
+    "desc": "本当にログアウトでしょうか？",
+    "clear_local": "ローカルデータをクリアする"
+  },
   "continue": "引き続き",
   "check_email": "メールボックスを確認してください",
   "check_email_desc": "メールボックスにリンクを送信します：{{email}}にチェックし確認してください",

--- a/public/locales/jp/common.json
+++ b/public/locales/jp/common.json
@@ -23,6 +23,7 @@
     "add": "追加",
     "yes": "はい",
     "remove": "削除",
+    "delete_channel": "チャンネルを削除",
     "edit": "編集",
     "edit_msg": "メッセージを編集する",
     "add_reaction": "リアクション",

--- a/public/locales/jp/setting.json
+++ b/public/locales/jp/setting.json
@@ -17,6 +17,7 @@
     "widget": "ウィジェット",
     "license": "ライセンス",
     "about": "このアプリについて",
+    "api_doc": "APIドキュメント",
     "faq": "FAQ",
     "terms": "プライバシーに関する説明",
     "feedback": "フィードバック"
@@ -55,8 +56,8 @@
     "lang": {
       "title": "言語",
       "desc": "言語の設定",
-      "en": "英語",
-      "zh": "中国語",
+      "en": "English",
+      "zh": "中文",
       "jp": "日本語"
     }
   },
@@ -67,7 +68,10 @@
     "expire": "有効期限",
     "create": "作成日時",
     "value": "内容",
-    "renew": "アップグ",
+    "renew": "ライセンスキをリニューアル",
+    "update": "ライセンスキーをアップロード",
+    "update_placeholder": "ライセンスキーをアップロードしてください",
+
     "renew_select": "アップグするライセンスを選択してください",
     "tip": {
       "title": "無料アップグレードを取得するチャンス！",
@@ -122,11 +126,25 @@
     "config": "説明",
     "param_key": "パラメータ",
     "default_value": "デフォルト値",
-    "remark": "メモ"
+    "remark": "メモ",
+    "param_host": "ユーザーIDでチットの相手を指定する",
+    "param_close_width": "ウィジェット閉じたままの幅",
+    "param_close_height": "ウィジェット閉じたままの高さ",
+    "param_open_width": "ウィジェット開きままの幅",
+    "param_open_height": "ウィジェット開きままの高さ"
   },
   "faq": {
     "client_version": "クライアントバージョン",
     "server_version": "サーバーバージョン",
     "build_time": "ビルド時間"
+  },
+  "api_doc": {
+    "desc": "VoceChat APIドキュメントを参照しで、VoceChatをカスタマイズできます。",
+    "access": "アクセス:",
+    "use_method": "使用方法:",
+    "step_1": "1. 自分のサーバーに切り替えください",
+    "step_2": "2. 登録済みのトークンを入力してください",
+    "step_2_desc": "トークンを取得するには、http headerのX-API-Keyにアクセスしてください、もしくは以下のテキストを直接コピーで使用してください👇",
+    "last": "3. 最後に各APIにはTry it Outオプションが付いてる、あれを使ってAPIを試すことができます"
   }
 }

--- a/public/locales/jp/setting.json
+++ b/public/locales/jp/setting.json
@@ -55,10 +55,7 @@
     },
     "lang": {
       "title": "言語",
-      "desc": "言語の設定",
-      "en": "English",
-      "zh": "中文",
-      "jp": "日本語"
+      "desc": "言語の設定"
     }
   },
   "license": {

--- a/public/locales/jp/welcome.json
+++ b/public/locales/jp/welcome.json
@@ -27,6 +27,11 @@
     "enter": "入ります",
     "last_tip": "現在、招待準備を終わりました",
     "last_desc": "リンクをメンバーに送信しましょう：",
-    "done": "完了"
+    "done": "完了",
+    "welcome_page": "ようこそ",
+    "set_name": "名前を設定",
+    "admin_account": "管理者アカウント",
+    "who_sign_up": "登録に関する権限設定",
+    "invites": "招待"
   }
 }


### PR DESCRIPTION
补充了新增加的翻译和对原译文的一部分修正
关于`设置界面语言`那边的翻译，一般来说语言选项的表示直接使用对应语言的译文会不会更好，比如：
```
 "en": "English",
 "zh": "中文",
 "jp": "日本語"
```
日语这边我是按照上面的样子进行了修改，如果感觉不对，可以联系我重新提pr